### PR TITLE
V0.5.0/bugfix/nullable apikey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.1]
+
+- Fix the issue that passing null value on API key will have exception
+
 ## [0.5.0]
 
 - Support private document google sheet for safety

--- a/lib/src/localization_generator.dart
+++ b/lib/src/localization_generator.dart
@@ -28,13 +28,15 @@ class LocalizationGenerator extends GeneratorForAnnotation<SheetLocalization> {
         'Accept': '*/*'
       };
       final docId = annotation.read('docId').stringValue;
-      final apiKey = annotation.read('apiKey').stringValue;
+      final apiKey = annotation.read('apiKey').isNull
+          ? null
+          : annotation.read('apiKey').stringValue;
 
       if (docId.isEmpty) {
         throw Exception('Doc id is required in locale_keys.dart');
       }
 
-      final response = apiKey.isNotEmpty
+      final response = apiKey?.isNotEmpty == true
           ? await http.get(
               Uri.parse(
                 "https://www.googleapis.com/drive/v3/files/$docId/export?mimeType=text/csv&key=$apiKey",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,5 +26,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
-
-flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sheet_loader_localization
 description: Download an CSV file and generates the localization keys from an online Google Sheet.
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/Hoang-Nguyenn
 repository: https://github.com/Hoang-Nguyenn/sheet_loader_localization
 issue_tracker: https://github.com/Hoang-Nguyenn/sheet_loader_localization/issues


### PR DESCRIPTION
Fix: Allow null API key for public Google Sheets

Previously, providing a null API key would cause an exception. This change allows the API key to be optional, enabling access to public Google Sheets without an API key.